### PR TITLE
Set Java version to 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,9 @@
     <camunda.version>7.16.0</camunda.version>
     <springBoot.version>2.5.6</springBoot.version>
 
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <version.java>1.8</version.java>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <version.java>11</version.java>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <failOnMissingWebXml>false</failOnMissingWebXml>


### PR DESCRIPTION
According to the trainer @javahippie the training project should use
Java 11 as base, since tests later will rely on Java 11 specifics