### PR TITLE
Add more ignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ hs_err_pid*
 
 # and DS_Store files
 */**/.DS_Store
+
+# Eclipse
+bin
+
+# H2
+*.db


### PR DESCRIPTION
When importing the project into Eclipse, Eclipse will use the /bin
folder as default output.

Also added *.db to ignore the created h2 database

Staged files after importing and starting the application:
<img width="718" alt="screenshot 2022-02-28 um 14 31 29" src="https://user-images.githubusercontent.com/265597/155992315-8ef959ea-575f-4bfa-b1ae-272c88c755b6.png">
.